### PR TITLE
Fix ip_address in Kubernetes

### DIFF
--- a/lib/zipkin/endpoint.rb
+++ b/lib/zipkin/endpoint.rb
@@ -2,7 +2,10 @@ require 'socket'
 
 module Zipkin
   class Endpoint
-    LOCAL_IP = Socket.ip_address_list.detect(&:ipv4_private?).ip_address
+    LOCAL_IP = (
+      Socket.ip_address_list.detect(&:ipv4_private?) ||
+      Socket.ip_address_list.reverse.detect(&:ipv4?)
+    ).ip_address
 
     def self.local_endpoint(service_name)
       {


### PR DESCRIPTION
```
NoMethodError: undefined method `ip_address' for nil:NilClass

/app/vendor/bundle/ruby/2.4.0/gems/zipkin-0.4.0/lib/zipkin/endpoint.rb:5:in
`<class:Endpoint>'
```