### PR TITLE
Add HTTPS support in emit_batch method

### DIFF
--- a/lib/zipkin/json_client.rb
+++ b/lib/zipkin/json_client.rb
@@ -30,6 +30,7 @@ module Zipkin
       return if spans.empty?
 
       http = Net::HTTP.new(@spans_uri.host, @spans_uri.port)
+      http.use_ssl = @spans_uri.scheme == 'https'
       request = Net::HTTP::Post.new(@spans_uri.request_uri, {
         'Content-Type' => 'application/json'
       })


### PR DESCRIPTION
Very simple one-liner. Works perfectly for me over here. Just for context, we have a bunch of applications deployed in Docker Swarm so https is the only way to go this side. Would be very happy to get the ugly monkey patch out of my code!