### PR TITLE
Update headers to reflect Zipkin spec

### DIFF
--- a/lib/zipkin/tracer.rb
+++ b/lib/zipkin/tracer.rb
@@ -64,10 +64,10 @@ module Zipkin
     def inject(span_context, format, carrier)
       case format
       when OpenTracing::FORMAT_TEXT_MAP
-        carrier['trace-id'] = span_context.trace_id
-        carrier['parent-id'] = span_context.parent_id
-        carrier['span-id'] = span_context.span_id
-        carrier['sampled'] = span_context.sampled? ? '1' : '0'
+        carrier['x-b3-traceid'] = span_context.trace_id
+        carrier['x-b3-spanparentid'] = span_context.parent_id
+        carrier['x-b3-spanid'] = span_context.span_id
+        carrier['x-b3-sampled'] = span_context.sampled? ? '1' : '0'
       when OpenTracing::FORMAT_RACK
         carrier['X-B3-TraceId'] = span_context.trace_id
         carrier['X-B3-ParentSpanId'] = span_context.parent_id
@@ -86,10 +86,10 @@ module Zipkin
     def extract(format, carrier)
       case format
       when OpenTracing::FORMAT_TEXT_MAP
-        trace_id = carrier['trace-id']
-        parent_id = carrier['parent-id']
-        span_id = carrier['span-id']
-        sampled = carrier['sampled'] == '1'
+        trace_id = carrier['x-b3-traceid']
+        parent_id = carrier['x-b3-parentspanid']
+        span_id = carrier['x-b3-spanid']
+        sampled = carrier['x-b3-sampled'] == '1'
 
         create_span_context(trace_id, span_id, parent_id, sampled)
       when OpenTracing::FORMAT_RACK

--- a/lib/zipkin/tracer.rb
+++ b/lib/zipkin/tracer.rb
@@ -65,7 +65,7 @@ module Zipkin
       case format
       when OpenTracing::FORMAT_TEXT_MAP
         carrier['x-b3-traceid'] = span_context.trace_id
-        carrier['x-b3-spanparentid'] = span_context.parent_id
+        carrier['x-b3-parentspanid'] = span_context.parent_id
         carrier['x-b3-spanid'] = span_context.span_id
         carrier['x-b3-sampled'] = span_context.sampled? ? '1' : '0'
       when OpenTracing::FORMAT_RACK

--- a/spec/zipkin/tracer_spec.rb
+++ b/spec/zipkin/tracer_spec.rb
@@ -86,22 +86,22 @@ describe Zipkin::Tracer do
       before { tracer.inject(span_context, OpenTracing::FORMAT_TEXT_MAP, carrier) }
 
       it 'sets trace-id' do
-        expect(carrier['trace-id']).to eq(trace_id)
+        expect(carrier['x-b3-traceid']).to eq(trace_id)
       end
 
       it 'sets parent-id' do
-        expect(carrier['parent-id']).to eq(parent_id)
+        expect(carrier['x-b3-parentspanid']).to eq(parent_id)
       end
 
       it 'sets span-id' do
-        expect(carrier['span-id']).to eq(span_id)
+        expect(carrier['x-b3-spanid']).to eq(span_id)
       end
 
       context 'when sampled' do
         let(:sampled) { true }
 
-        it 'sets sampled to 1' do
-          expect(carrier['sampled']).to eq('1')
+        it 'sets sampled to true' do
+          expect(carrier['x-b3-sampled']).to eq('1')
         end
       end
 
@@ -109,7 +109,7 @@ describe Zipkin::Tracer do
         let(:sampled) { false }
 
         it 'sets sampled to 0' do
-          expect(carrier['sampled']).to eq('0')
+          expect(carrier['x-b3-sampled']).to eq('0')
         end
       end
     end
@@ -157,10 +157,10 @@ describe Zipkin::Tracer do
     context 'when FORMAT_TEXT_MAP' do
       let(:carrier) do
         {
-          'trace-id' => trace_id,
-          'parent-id' => parent_id,
-          'span-id' => span_id,
-          'sampled' => sampled
+          'x-b3-traceid' => trace_id,
+          'x-b3-parentspanid' => parent_id,
+          'x-b3-spanid' => span_id,
+          'x-b3-sampled' => sampled
         }
       end
       let(:span_context) { tracer.extract(OpenTracing::FORMAT_TEXT_MAP, carrier) }


### PR DESCRIPTION
According to the instrumenting a library page: https://zipkin.io/pages/instrumenting.html

Headers for trace context should be:
x-b3-traceid for the trace id
x-b3-parentspanid for the parent span id
x-b3-spanid for the span id
x-b3-sampled for the sampled flag
x-b3-flags for the debug flag

The TEXT_MAP format currently uses trace-id, parent-id, span-id and sampled. This causes issues when interoping with opentracing zipkin libraries for other languages, such as Go: https://github.com/openzipkin/zipkin-go-opentracing/blob/master/propagation_ot.go#L24-L34

This PR changes the TEXT_MAP format to use standard zipkin headers. This is necessary to use this format when instrumenting gRPC microservices, as there is no Rack ENV to support HTTP header formatting.