### PR TITLE
Deprecate `log` method and add `log_kv` method

### DIFF
--- a/lib/zipkin/span.rb
+++ b/lib/zipkin/span.rb
@@ -45,12 +45,23 @@ module Zipkin
       nil
     end
 
-    # Add a log entry to this span
+    # @deprecated Use {#log_kv} instead.
+    # Reason: event is an optional standard log field defined in spec and not required.  Also,
+    # method name {#log_kv} is more consistent with other language implementations such as Python and Go.
     #
+    # Add a log entry to this span
     # @param event [String] event name for the log
     # @param timestamp [Time] time of the log
     # @param fields [Hash] Additional information to log
     def log(event: nil, timestamp: Time.now, **fields)
+      warn "Span#log is deprecated.  Please use Span#log_kv instead."
+      nil
+    end
+
+    # Add a log entry to this span
+    # @param timestamp [Time] time of the log
+    # @param fields [Hash] Additional information to log
+    def log_kv(timestamp: Time.now, **fields)
       nil
     end
 

--- a/lib/zipkin/span.rb
+++ b/lib/zipkin/span.rb
@@ -2,7 +2,7 @@ module Zipkin
   class Span
     attr_accessor :operation_name
 
-    attr_reader :context, :start_time, :tags
+    attr_reader :context, :start_time, :tags, :logs
 
     # Creates a new {Span}
     #
@@ -11,12 +11,13 @@ module Zipkin
     # @param collector [Collector] the span collector
     #
     # @return [Span] a new Span
-    def initialize(context, operation_name, collector, start_time: Time.now, tags: {})
+    def initialize(context, operation_name, collector, start_time: Time.now, tags: {}, logs: [])
       @context = context
       @operation_name = operation_name
       @collector = collector
       @start_time = start_time
       @tags = tags
+      @logs = logs
     end
 
     # Set a tag value on this span
@@ -62,7 +63,11 @@ module Zipkin
     # @param timestamp [Time] time of the log
     # @param fields [Hash] Additional information to log
     def log_kv(timestamp: Time.now, **fields)
-      nil
+      @logs.push({
+        timestamp: timestamp,
+        fields: fields,
+      })
+      self
     end
 
     # Finish the {Span}

--- a/spec/zipkin/span_spec.rb
+++ b/spec/zipkin/span_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe Zipkin::Span do
+  describe '.log_kv' do
+    let(:span) do
+      described_class.new(nil, 'operation_name', nil)
+    end
+    let(:feilds) { { key: 'value' } }
+
+    it 'return nil' do
+      expect(span.log_kv(feilds)).to be_nil
+    end
+  end
+end

--- a/spec/zipkin/span_spec.rb
+++ b/spec/zipkin/span_spec.rb
@@ -5,10 +5,40 @@ RSpec.describe Zipkin::Span do
     let(:span) do
       described_class.new(nil, 'operation_name', nil)
     end
-    let(:feilds) { { key: 'value' } }
+    let(:fields) { { key1: 'value1', key2: 'value2' } }
 
-    it 'return nil' do
-      expect(span.log_kv(feilds)).to be_nil
+    it 'return self' do
+      expect(span.log_kv(fields)).to eq(span)
+    end
+
+    subject do
+      span.log_kv(args)
+      span.logs.first
+    end
+
+    context 'when args includes timestamp' do
+      let(:timestamp) { Time.now }
+      let(:args) { fields.merge(timestamp: timestamp) }
+
+      it 'sets fields in log' do
+        expect(subject).to include({ fields: fields })
+      end
+      it 'sets timestamp in log' do
+        expect(subject).to include({ timestamp: timestamp })
+      end
+    end
+
+    context 'when args dose not include timestamp' do
+      let(:args) { fields }
+
+      it 'sets fields in log' do
+        expect(subject).to include({ fields: fields })
+      end
+
+      it 'sets timestamp in log' do
+        expect(subject).to have_key(:timestamp)
+        expect(subject[:timestamp]).to be_kind_of(Time)
+      end
     end
   end
 end


### PR DESCRIPTION
opentracing-ruby deprecated `log` and added `log_kv`.
This PR add deprecated annotation and `log_kv`.