### PR TITLE
Allow to set custom logger

### DIFF
--- a/lib/zipkin/json_client.rb
+++ b/lib/zipkin/json_client.rb
@@ -4,10 +4,11 @@ require 'json'
 
 module Zipkin
   class JsonClient
-    def initialize(url:, collector:, flush_interval:)
+    def initialize(url:, collector:, flush_interval:, logger: Logger.new(STDOUT))
       @collector = collector
       @flush_interval = flush_interval
       @spans_uri = URI.parse("#{url}/api/v1/spans")
+      @logger = logger
     end
 
     def start
@@ -38,11 +39,11 @@ module Zipkin
       request.body = JSON.dump(spans)
       response = http.request(request)
 
-      if response.code != 202
-        STDERR.puts(response.body)
+      if response.code.to_s != '202'
+        @logger.error("Received bad response from Zipkin. status: #{response.code}, body: #{response.body.inspect}")
       end
     rescue StandardError => e
-      STDERR.puts("Error emitting spans batch: #{e.message}\n#{e.backtrace.join("\n")}")
+      @logger.error("Error emitting spans batch: #{e.message}\n#{e.backtrace.join("\n")}")
     end
   end
 end

--- a/lib/zipkin/json_client.rb
+++ b/lib/zipkin/json_client.rb
@@ -39,7 +39,7 @@ module Zipkin
       request.body = JSON.dump(spans)
       response = http.request(request)
 
-      if response.code.to_s != '202'
+      if response.code != '202'
         @logger.error("Received bad response from Zipkin. status: #{response.code}, body: #{response.body.inspect}")
       end
     rescue StandardError => e


### PR DESCRIPTION
Use logger to log errors and allow to set a custom logger. Also, fixes a bug that resulted in writing new line characters to stdout on successful responses from zipkin.