### PR TITLE
Add logging support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,12 @@ Style/IfUnlessModifier:
 RSpec/NestedGroups:
   Max: 4
 
+RSpec/ExampleLength:
+  Enabled: no
+
+RSpec/MultipleExpectations:
+  Enabled: no
+
 Metrics/BlockLength:
   Enabled: no
 

--- a/lib/zipkin/collector/log_annotations.rb
+++ b/lib/zipkin/collector/log_annotations.rb
@@ -1,0 +1,26 @@
+module Zipkin
+  class Collector
+    module LogAnnotations
+      def self.build(span, endpoint)
+        span.logs.map do |log|
+          {
+            timestamp: Timestamp.create(log.fetch(:timestamp)),
+            value: format_log_value(log),
+            endpoint: endpoint
+          }
+        end
+      end
+
+      def self.format_log_value(log)
+        if log.keys == %i[event timestamp]
+          log.fetch(:event)
+        else
+          log
+            .reject { |key, _value| key == :timestamp }
+            .map { |key, value| "#{key}=#{value}" }
+            .join(' ')
+        end
+      end
+    end
+  end
+end

--- a/lib/zipkin/collector/timestamp.rb
+++ b/lib/zipkin/collector/timestamp.rb
@@ -1,0 +1,9 @@
+module Zipkin
+  class Collector
+    module Timestamp
+      def self.create(time)
+        (time.to_f * 1_000_000).to_i
+      end
+    end
+  end
+end

--- a/lib/zipkin/span.rb
+++ b/lib/zipkin/span.rb
@@ -2,7 +2,7 @@ module Zipkin
   class Span
     attr_accessor :operation_name
 
-    attr_reader :context, :start_time, :tags
+    attr_reader :context, :start_time, :tags, :logs
 
     # Creates a new {Span}
     #
@@ -17,6 +17,7 @@ module Zipkin
       @collector = collector
       @start_time = start_time
       @tags = tags
+      @logs = []
     end
 
     # Set a tag value on this span
@@ -47,14 +48,10 @@ module Zipkin
 
     # Add a log entry to this span
     #
-    # @param event [String] event name for the log
-    # @param timestamp [Time] time of the log
-    # @param fields [Hash] Additional information to log
-    #
     # @deprecated Use {#log_kv} instead.
-    def log(event: nil, timestamp: Time.now, **fields)
+    def log(*args)
       warn 'Span#log is deprecated. Please use Span#log_kv instead.'
-      nil
+      log_kv(*args)
     end
 
     # Add a log entry to this span
@@ -62,6 +59,7 @@ module Zipkin
     # @param timestamp [Time] time of the log
     # @param fields [Hash] Additional information to log
     def log_kv(timestamp: Time.now, **fields)
+      @logs << fields.merge(timestamp: timestamp)
       nil
     end
 

--- a/script/create_trace
+++ b/script/create_trace
@@ -33,6 +33,8 @@ downstream_span = tracer2.start_span(
   child_of: inner_span,
   tags: { 'span.kind' => 'server' }
 )
+downstream_span.log_kv(event: 'custom-event')
+downstream_span.log_kv(foo: 'bar', baz: 'buz')
 sleep 0.5
 downstream_span.finish
 

--- a/spec/zipkin/collector/log_annotations_spec.rb
+++ b/spec/zipkin/collector/log_annotations_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Zipkin::Collector::LogAnnotations do
+  let(:span) { Zipkin::Span.new(nil, 'operation_name', nil) }
+  let(:endpoint) { 'local-endpoint' }
+
+  context 'when log includes only event and timestamp' do
+    it 'uses event as the annotation value' do
+      message = 'some message'
+      span.log_kv(event: message)
+      expect(described_class.build(span, endpoint)).to include(
+        timestamp: instance_of(Integer),
+        value: message,
+        endpoint: endpoint
+      )
+    end
+  end
+
+  context 'when log includes multiple fields' do
+    it 'converts fields into string form' do
+      span.log_kv(foo: 'bar', baz: 'buz')
+      expect(described_class.build(span, endpoint)).to include(
+        timestamp: instance_of(Integer),
+        value: 'foo=bar baz=buz',
+        endpoint: endpoint
+      )
+    end
+  end
+end

--- a/spec/zipkin/span_spec.rb
+++ b/spec/zipkin/span_spec.rb
@@ -4,8 +4,26 @@ RSpec.describe Zipkin::Span do
   describe '#log_kv' do
     let(:span) { described_class.new(nil, 'operation_name', nil) }
 
-    it 'return nil' do
+    it 'returns nil' do
       expect(span.log_kv(key: 'value')).to be_nil
+    end
+
+    it 'adds log to span' do
+      log = { key1: 'value1', key2: 'value2' }
+      span.log_kv(log)
+
+      expect(span.logs.count).to eq(1)
+      expect(span.logs[0]).to include(
+        log.merge(timestamp: instance_of(Time))
+      )
+    end
+
+    it 'adds log to span with specific timestamp' do
+      log = { key1: 'value1', key2: 'value2', timestamp: Time.now }
+      span.log_kv(log)
+
+      expect(span.logs.count).to eq(1)
+      expect(span.logs[0]).to eq(log)
     end
   end
 end


### PR DESCRIPTION
This follows log implementation from brave-opentracing library
https://github.com/openzipkin-contrib/brave-opentracing/blob/2698b56448da9b223808d696cf563bdd8c729c3d/src/main/java/brave/opentracing/BraveSpan.java#L160-L169

Example from `script/create_trace`:
<img width="926" alt="screen shot 2018-04-12 at 23 17 04" src="https://user-images.githubusercontent.com/3438/38701878-bd0b071a-3ea7-11e8-82d9-db2920110fbc.png">

Fixes #10