### PR TITLE
Use Faraday to allow setting SSL configurations

### DIFF
--- a/lib/zipkin/json_client.rb
+++ b/lib/zipkin/json_client.rb
@@ -34,8 +34,8 @@ module Zipkin
         req.body = spans
       end
 
-      if response.code != '202'
-        @logger.error("Received bad response from Zipkin. status: #{response.code}, body: #{response.body.inspect}")
+      if response.status != 202
+        @logger.error("Received bad response from Zipkin. status: #{response.status}, body: #{response.body.inspect}")
       end
     rescue StandardError => e
       @logger.error("Error emitting spans batch: #{e.message}\n#{e.backtrace.join("\n")}")

--- a/lib/zipkin/json_client.rb
+++ b/lib/zipkin/json_client.rb
@@ -29,15 +29,10 @@ module Zipkin
 
     def emit_batch(spans)
       return if spans.empty?
-
-      http = Net::HTTP.new(@spans_uri.host, @spans_uri.port)
-      http.use_ssl = @spans_uri.scheme == 'https'
-      request = Net::HTTP::Post.new(
-        @spans_uri.request_uri,
-        'Content-Type' => 'application/json'
-      )
-      request.body = JSON.dump(spans)
-      response = http.request(request)
+      response = Faraday.post(@spans_uri) do |req|
+        req.headers['Content-Type'] = 'application/json'
+        req.body = spans
+      end
 
       if response.code != '202'
         @logger.error("Received bad response from Zipkin. status: #{response.code}, body: #{response.body.inspect}")

--- a/lib/zipkin/json_client.rb
+++ b/lib/zipkin/json_client.rb
@@ -31,7 +31,7 @@ module Zipkin
       return if spans.empty?
       response = Faraday.post(@spans_uri) do |req|
         req.headers['Content-Type'] = 'application/json'
-        req.body = spans
+        req.body = JSON.dump(spans)
       end
 
       if response.status != 202

--- a/spec/zipkin/collector/log_annotations_spec.rb
+++ b/spec/zipkin/collector/log_annotations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Zipkin::Collector::LogAnnotations do
       message = 'some message'
       span.log_kv(event: message)
       expect(described_class.build(span)).to include(
-        timestamp: instance_of(Integer),
+        timestamp: instance_of(Fixnum),
         value: message
       )
     end
@@ -18,7 +18,7 @@ RSpec.describe Zipkin::Collector::LogAnnotations do
     it 'converts fields into string form' do
       span.log_kv(foo: 'bar', baz: 'buz')
       expect(described_class.build(span)).to include(
-        timestamp: instance_of(Integer),
+        timestamp: instance_of(Fixnum),
         value: 'foo=bar baz=buz'
       )
     end

--- a/zipkin.gemspec
+++ b/zipkin.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.54.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.24.0'
 
+  spec.add_dependency 'faraday'
   spec.add_dependency 'json'
-  spec.add_dependency 'opentracing', '~> 0.3'
+  spec.add_dependency 'opentracing', '>= 0.3'
 end


### PR DESCRIPTION
Also loosens the expectation on opentracing

When trying to get this library to use a jaeger instance behind peer verified ssl I was unable to hook in. By using Faraday I can write some middleware that takes care of this for me.