### PR TITLE
Add scopes support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,12 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Enabled: no
 
+Metrics/ClassLength:
+  Enabled: no
+
+Metrics/ParameterLists:
+  Enabled: no
+
 Lint/UnusedMethodArgument:
   Enabled: no
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,16 @@ gem 'zipkin'
 require 'zipkin/tracer'
 OpenTracing.global_tracer = Zipkin::Tracer.build(url: 'http://localhost:9411', service_name: 'echo')
 
-span = OpenTracing.start_span('span name')
-span.finish
+OpenTracing.start_active_span('span name') do
+  # do something
+
+  OpenTracing.start_active_span('inner span name') do
+    # do something else
+  end
+end
 ```
+
+See [opentracing-ruby](https://github.com/opentracing/opentracing-ruby) for more examples.
 
 ## Development
 

--- a/lib/zipkin/scope.rb
+++ b/lib/zipkin/scope.rb
@@ -1,0 +1,36 @@
+module Zipkin
+  # Scope represents an OpenTracing Scope
+  #
+  # See http://www.opentracing.io for more information.
+  class Scope
+    def initialize(span, scope_stack, finish_on_close:)
+      @span = span
+      @scope_stack = scope_stack
+      @finish_on_close = finish_on_close
+      @closed = false
+    end
+
+    # Return the Span scoped by this Scope
+    #
+    # @return [Span]
+    attr_reader :span
+
+    # Close scope
+    #
+    # Mark the end of the active period for the current thread and Scope,
+    # updating the ScopeManager#active in the process.
+    def close
+      raise "Tried to close already closed span: #{inspect}" if @closed
+      @closed = true
+
+      @span.finish if @finish_on_close
+      removed_scope = @scope_stack.pop
+
+      if removed_scope != self # rubocop:disable Style/GuardClause
+        raise 'Removed non-active scope, ' \
+          "removed: #{removed_scope.inspect}, "\
+          "expected: #{inspect}"
+      end
+    end
+  end
+end

--- a/lib/zipkin/scope_manager.rb
+++ b/lib/zipkin/scope_manager.rb
@@ -1,0 +1,45 @@
+require_relative 'scope_manager/scope_stack'
+require_relative 'scope_manager/scope_identifier'
+
+module Zipkin
+  # ScopeManager represents an OpenTracing ScopeManager
+  #
+  # See http://www.opentracing.io for more information.
+  #
+  # The ScopeManager interface abstracts both the activation of Span instances
+  # via ScopeManager#activate and access to an active Span/Scope via
+  # ScopeManager#active
+  #
+  class ScopeManager
+    def initialize
+      @scope_stack = ScopeStack.new
+    end
+
+    # Make a span instance active
+    #
+    # @param span [Span] the Span that should become active
+    # @param finish_on_close [Boolean] whether the Span should automatically be
+    #   finished when Scope#close is called
+    # @return [Scope] instance to control the end of the active period for the
+    #  Span. It is a programming error to neglect to call Scope#close on the
+    #  returned instance.
+    def activate(span, finish_on_close: true)
+      return active if active && active.span == span
+      scope = Scope.new(span, @scope_stack, finish_on_close: finish_on_close)
+      @scope_stack.push(scope)
+      scope
+    end
+
+    # Return active scope
+    #
+    # If there is a non-null Scope, its wrapped Span becomes an implicit parent
+    # (as Reference#CHILD_OF) of any newly-created Span at
+    # Tracer#start_active_span or Tracer#start_span time.
+    #
+    # @return [Scope] the currently active Scope which can be used to access the
+    #   currently active Span.
+    def active
+      @scope_stack.peek
+    end
+  end
+end

--- a/lib/zipkin/scope_manager/scope_identifier.rb
+++ b/lib/zipkin/scope_manager/scope_identifier.rb
@@ -1,0 +1,11 @@
+module Zipkin
+  class ScopeManager
+    # @api private
+    class ScopeIdentifier
+      def self.generate
+        # 65..90.chr are characters between A and Z
+        "opentracing_#{(0...8).map { rand(65..90).chr }.join}".to_sym
+      end
+    end
+  end
+end

--- a/lib/zipkin/scope_manager/scope_stack.rb
+++ b/lib/zipkin/scope_manager/scope_stack.rb
@@ -1,0 +1,26 @@
+module Zipkin
+  class ScopeManager
+    # @api private
+    class ScopeStack
+      def initialize
+        # Generate a random identifier to use as the Thread.current key. This is
+        # needed so that it would be possible to create multiple tracers in one
+        # thread (mostly useful for testing purposes)
+        @scope_identifier = ScopeIdentifier.generate
+        Thread.current[@scope_identifier] = []
+      end
+
+      def push(scope)
+        Thread.current[@scope_identifier] << scope
+      end
+
+      def pop
+        Thread.current[@scope_identifier].pop
+      end
+
+      def peek
+        Thread.current[@scope_identifier].last
+      end
+    end
+  end
+end

--- a/lib/zipkin/tracer.rb
+++ b/lib/zipkin/tracer.rb
@@ -8,6 +8,8 @@ require_relative 'trace_id'
 require_relative 'json_client'
 require_relative 'endpoint'
 require_relative 'collector'
+require_relative 'scope_manager'
+require_relative 'scope'
 
 module Zipkin
   class Tracer
@@ -29,30 +31,50 @@ module Zipkin
       @collector = collector
       @sender = sender
       @logger = logger
+      @scope_manager = ScopeManager.new
     end
 
     def stop
       @sender.stop
     end
 
-    # Starts a new span.
+    # @return [ScopeManager] the current ScopeManager, which may be a no-op but
+    #   may not be nil.
+    attr_reader :scope_manager
+
+    # @return [Span, nil] the active span. This is a shorthand for
+    #   `scope_manager.active.span`, and nil will be returned if
+    #   Scope#active is nil.
+    def active_span
+      scope = scope_manager.active
+      scope.span if scope
+    end
+
+    # Starts a new span
+    #
+    # This is similar to #start_active_span, but the returned Span will not be
+    # registered via the ScopeManager.
     #
     # @param operation_name [String] The operation name for the Span
     # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
-    #        the newly-started Span. If a Span instance is provided, its
-    #        context is automatically substituted.
+    #   the newly-started Span. If a Span instance is provided, its
+    #   context is automatically substituted.
     # @param start_time [Time] When the Span started, if not now
     # @param tags [Hash] Tags to assign to the Span at start time
+    # @param ignore_active_scope [Boolean] whether to create an implicit
+    #   References#CHILD_OF reference to the ScopeManager#active.
     #
     # @return [Span] The newly-started Span
-    def start_span(operation_name, child_of: nil, start_time: Time.now, tags: {}, **)
-      context =
-        if child_of
-          parent_context = child_of.respond_to?(:context) ? child_of.context : child_of
-          SpanContext.create_from_parent_context(parent_context)
-        else
-          SpanContext.create_parent_context
-        end
+    def start_span(operation_name,
+                   child_of: nil,
+                   start_time: Time.now,
+                   tags: {},
+                   ignore_active_scope: false,
+                   **)
+      context = prepare_span_context(
+        child_of: child_of,
+        ignore_active_scope: ignore_active_scope
+      )
       Span.new(
         context,
         operation_name,
@@ -60,6 +82,61 @@ module Zipkin
         start_time: start_time,
         tags: tags
       )
+    end
+
+    # Creates a newly started and activated Scope
+    #
+    # If the Tracer's ScopeManager#active is not nil, no explicit references
+    # are provided, and `ignore_active_scope` is false, then an inferred
+    # References#CHILD_OF reference is created to the ScopeManager#active's
+    # SpanContext when start_active is invoked.
+    #
+    # @param operation_name [String] The operation name for the Span
+    # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
+    #   the newly-started Span. If a Span instance is provided, its
+    #   context is automatically substituted. See [Reference] for more
+    #   information.
+    #
+    #   If specified, the `references` parameter must be omitted.
+    # @param references [Array<Reference>] An array of reference
+    #   objects that identify one or more parent SpanContexts.
+    # @param start_time [Time] When the Span started, if not now
+    # @param tags [Hash] Tags to assign to the Span at start time
+    # @param ignore_active_scope [Boolean] whether to create an implicit
+    #   References#CHILD_OF reference to the ScopeManager#active.
+    # @param finish_on_close [Boolean] whether span should automatically be
+    #   finished when Scope#close is called
+    # @yield [Scope] If an optional block is passed to start_active it will
+    #   yield the newly-started Scope. If `finish_on_close` is true then the
+    #   Span will be finished automatically after the block is executed.
+    # @return [Scope] The newly-started and activated Scope
+    def start_active_span(operation_name,
+                          child_of: nil,
+                          references: nil,
+                          start_time: Time.now,
+                          tags: nil,
+                          ignore_active_scope: false,
+                          finish_on_close: true,
+                          **)
+      span = start_span(
+        operation_name,
+        child_of: child_of,
+        references: references,
+        start_time: start_time,
+        tags: tags,
+        ignore_active_scope: ignore_active_scope
+      )
+      scope = @scope_manager.activate(span, finish_on_close: finish_on_close)
+
+      if block_given?
+        begin
+          yield scope
+        ensure
+          scope.close
+        end
+      end
+
+      scope
     end
 
     # Inject a SpanContext into the given carrier
@@ -122,6 +199,22 @@ module Zipkin
         span_id: span_id,
         sampled: sampled
       )
+    end
+
+    def prepare_span_context(child_of:, ignore_active_scope:)
+      if child_of
+        parent_context = child_of.respond_to?(:context) ? child_of.context : child_of
+        return SpanContext.create_from_parent_context(parent_context)
+      end
+
+      unless ignore_active_scope
+        active_scope = @scope_manager.active
+        if active_scope
+          return SpanContext.create_from_parent_context(active_scope.span.context)
+        end
+      end
+
+      SpanContext.create_parent_context
     end
   end
 end

--- a/spec/zipkin/scope_manager/scope_identifier_spec.rb
+++ b/spec/zipkin/scope_manager/scope_identifier_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Zipkin::ScopeManager::ScopeIdentifier do
+  describe '.generate' do
+    it 'generates an identifier' do
+      id = described_class.generate
+      expect(id).to be_a(Symbol)
+      expect(id).to match(/opentracing_[A-Z]{8}/)
+    end
+  end
+end

--- a/spec/zipkin/scope_manager_spec.rb
+++ b/spec/zipkin/scope_manager_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe Zipkin::ScopeManager do
+  let(:scope_manager) { described_class.new }
+  let(:span) { instance_spy(Zipkin::Span) }
+
+  context 'when activating a span' do
+    it 'marks the span active' do
+      scope_manager.activate(span)
+      expect(scope_manager.active.span).to eq(span)
+    end
+
+    it 'changes the active span' do
+      span2 = instance_spy(Zipkin::Span)
+
+      scope_manager.activate(span)
+      scope_manager.activate(span2)
+      expect(scope_manager.active.span).to eq(span2)
+    end
+  end
+
+  context 'when closing an active span' do
+    it 'reverts to the previous active span' do
+      span2 = instance_spy(Zipkin::Span)
+
+      scope_manager.activate(span)
+
+      scope_manager.activate(span2)
+      scope_manager.active.close
+
+      expect(scope_manager.active.span).to eq(span)
+    end
+  end
+end

--- a/spec/zipkin/scope_spec.rb
+++ b/spec/zipkin/scope_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.describe Zipkin::Scope do
+  let(:span) { instance_spy(Zipkin::Span) }
+  let(:scope_stack) { Zipkin::ScopeManager::ScopeStack.new }
+  let(:finish_on_close) { true }
+  let(:scope) { described_class.new(span, scope_stack, finish_on_close: finish_on_close) }
+
+  before do
+    scope_stack.push(scope)
+  end
+
+  describe '#span' do
+    it 'returns scope span' do
+      scope = described_class.new(span, scope_stack, finish_on_close: true)
+      expect(scope.span).to eq(span)
+    end
+  end
+
+  describe '#close' do
+    context 'when finish_on_close is true' do
+      let(:finish_on_close) { true }
+
+      it 'finishes the span' do
+        scope.close
+        expect(scope.span).to have_received(:finish)
+      end
+
+      it 'removes the scope from the scope stack' do
+        expect(scope_stack.peek).to eq(scope)
+        scope.close
+        expect(scope_stack.peek).to eq(nil)
+      end
+    end
+
+    context 'when finish_on_close is false' do
+      let(:finish_on_close) { false }
+
+      it 'does not finish the span' do
+        scope.close
+        expect(scope.span).not_to have_received(:finish)
+      end
+
+      it 'removes the scope from the scope stack' do
+        expect(scope_stack.peek).to eq(scope)
+        scope.close
+        expect(scope_stack.peek).to eq(nil)
+      end
+    end
+
+    context 'when scope is already closed' do
+      before { scope.close }
+
+      it 'throws an exception' do
+        expect { scope.close }
+          .to raise_error("Tried to close already closed span: #{scope.inspect}")
+      end
+    end
+  end
+end

--- a/spec/zipkin/tracer_spec.rb
+++ b/spec/zipkin/tracer_spec.rb
@@ -26,7 +26,7 @@ describe Zipkin::Tracer do
       end
     end
 
-    context 'when a child span context' do
+    context 'when a child span context is provided' do
       let(:root_span) { tracer.start_span(root_operation_name) }
       let(:span) { tracer.start_span(operation_name, child_of: root_span.context) }
       let(:root_operation_name) { 'root-operation-name' }
@@ -46,7 +46,7 @@ describe Zipkin::Tracer do
       end
     end
 
-    context 'when a child span' do
+    context 'when a child span is provided' do
       let(:root_span) { tracer.start_span(root_operation_name) }
       let(:span) { tracer.start_span(operation_name, child_of: root_span) }
       let(:root_operation_name) { 'root-operation-name' }
@@ -64,6 +64,104 @@ describe Zipkin::Tracer do
           expect(span.context.parent_id).not_to be_nil
         end
       end
+    end
+  end
+
+  describe '#start_active_span' do
+    let(:operation_name) { 'operator-name' }
+
+    context 'when a root span' do
+      let(:scope) { tracer.start_active_span(operation_name) }
+      let(:span) { scope.span }
+
+      describe 'span context' do
+        it 'has span_id' do
+          expect(span.context.span_id).not_to be_nil
+        end
+
+        it 'has trace_id' do
+          expect(span.context.trace_id).not_to be_nil
+        end
+
+        it 'does not have parent_id' do
+          expect(span.context.parent_id).to be_nil
+        end
+      end
+    end
+
+    context 'when a child span context is provided' do
+      let(:root_span) { tracer.start_span(root_operation_name) }
+      let(:scope) { tracer.start_active_span(operation_name, child_of: root_span.context) }
+      let(:span) { scope.span }
+      let(:root_operation_name) { 'root-operation-name' }
+
+      describe 'span context' do
+        it 'has span_id' do
+          expect(span.context.span_id).not_to be_nil
+        end
+
+        it 'has trace_id' do
+          expect(span.context.trace_id).not_to be_nil
+        end
+
+        it 'does not have parent_id' do
+          expect(span.context.parent_id).not_to be_nil
+        end
+      end
+    end
+
+    context 'when a child span is provided' do
+      let(:root_span) { tracer.start_span(root_operation_name) }
+      let(:scope) { tracer.start_active_span(operation_name, child_of: root_span) }
+      let(:span) { scope.span }
+      let(:root_operation_name) { 'root-operation-name' }
+
+      describe 'span context' do
+        it 'has span_id' do
+          expect(span.context.span_id).not_to be_nil
+        end
+
+        it 'has trace_id' do
+          expect(span.context.trace_id).not_to be_nil
+        end
+
+        it 'does not have parent_id' do
+          expect(span.context.parent_id).not_to be_nil
+        end
+      end
+    end
+
+    context 'when already existing active span' do
+      let(:root_operation_name) { 'root-operation-name' }
+
+      it 'uses active span as a parent span' do
+        tracer.start_active_span(root_operation_name) do |parent_scope|
+          tracer.start_active_span(operation_name) do |scope|
+            expect(scope.span.context.parent_id).to eq(parent_scope.span.context.span_id)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#active_span' do
+    let(:root_operation_name) { 'root-operation-name' }
+    let(:operation_name) { 'operation-name' }
+
+    it 'returns the span of the active scope' do
+      expect(tracer.active_span).to eq(nil)
+
+      tracer.start_active_span(root_operation_name) do |parent_scope|
+        expect(tracer.active_span).to eq(parent_scope.span)
+
+        tracer.start_active_span(operation_name) do |scope|
+          expect(tracer.active_span).to eq(scope.span)
+        end
+
+        expect(tracer.active_span).to eq(parent_scope.span)
+      end
+
+      expect(tracer.active_span).to eq(nil)
     end
   end
 


### PR DESCRIPTION
Scopes were introduced in opentracing-ruby v0.4.1. See
https://github.com/opentracing/opentracing-ruby for more information how
scopes behave and why are they useful.

In short: ScopeManager stores Scope information in Thread.current so
that the client does not have to explicitly pass spans in the
application code to create new child spans.