### PR TITLE
replace shorthand with ruby 3.0 supported call

### DIFF
--- a/lib/zipkin/span.rb
+++ b/lib/zipkin/span.rb
@@ -29,7 +29,7 @@ module Zipkin
       @logs = []
       @references = references
 
-      tags.each(&method(:set_tag))
+      tags.each { |key, value| set_tag(key, value) }
     end
 
     # Set a tag value on this span


### PR DESCRIPTION
due to [this change](https://rubyreferences.github.io/rubychanges/3.0.html#hasheach-consistently-yields-a-2-element-array-to-lambdas) for ruby versions 3.0 the used shorthand for `set_tag` will result in 
```
ArgumentError: wrong number of arguments (given 1, expected 2)
from ../zipkin-ruby-opentracing/lib/zipkin/span.rb:40:in `set_tag'
```

this is a compatible fix